### PR TITLE
Holiday extension1 - complete

### DIFF
--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -4,7 +4,7 @@
   <p>Upcoming Holidays:</p>
   <ol>
     <% @holidays.each_with_index do |holiday, index| %>
-      <li id="holiday-<%= holiday.name %>">
+      <li id="holiday-<%= index %>">
         <%= holiday.name %>, on <%= holiday.date %>
         <%= link_to "Create #{holiday.name} Discount", "/merchant/#{@merchant.id}/bulk_discounts/new?holiday=#{index}" %>
       </li>

--- a/spec/features/merchants/discounts/index_spec.rb
+++ b/spec/features/merchants/discounts/index_spec.rb
@@ -63,14 +63,20 @@ RSpec.describe "Merchant Bulk Discounts Index" do
 
   it 'shows a section with upcoming holidays and 3 upcoming US holidays are listed' do
     expect(page).to have_content("Upcoming Holidays:")
-    # within("#holiday-#{@holiday_1.name}") do
-    #   expect(page).to have_content(@holiday_1.date)
-    #   expect(page).to have_content(@holiday_1.name)
-    # end
+    within("#holiday-0") do
+      expect(page).to have_content(@holiday_1.date)
+      expect(page).to have_content(@holiday_1.name)
+    end
+
+    within("#holiday-1") do
       expect(page).to have_content(@holiday_2.date)
       expect(page).to have_content(@holiday_2.name)
+    end
+
+    within("#holiday-2") do
       expect(page).to have_content(@holiday_3.date)
       expect(page).to have_content(@holiday_3.name)
+    end
   end
 
   it 'shows a link to create a new bulk discount that I can click on' do
@@ -91,7 +97,7 @@ RSpec.describe "Merchant Bulk Discounts Index" do
     end
   end
 
-  it 'can delete a bulk discount' do 
+  it 'can delete a bulk discount' do
     within("#discounted-item-#{@discount_2.id}") do
       click_link "Delete discount #{@discount_2.id}"
     end
@@ -99,5 +105,15 @@ RSpec.describe "Merchant Bulk Discounts Index" do
     expect(current_path).to eq("/merchant/#{@merchant.id}/bulk_discounts")
 
     expect(page).to_not have_content(@discount_2.id)
+  end
+
+  it 'shows a link to create a new holiday discount that I can click on' do
+    within("#holiday-0") do
+      expect(page).to have_content(@holiday_1.date)
+      expect(page).to have_content(@holiday_1.name)
+      click_link("Create #{@holiday_1.name} Discount")
+    end
+
+    expect(current_path).to eq("/merchant/#{@merchant.id}/bulk_discounts/new")
   end
 end

--- a/spec/features/merchants/discounts/new_spec.rb
+++ b/spec/features/merchants/discounts/new_spec.rb
@@ -74,4 +74,15 @@ RSpec.describe "Merchant Bulk Discounts New Page" do
     expect(page).to have_content("Percentage discount: 50.0%")
     expect(page).to have_content("Quantity threshold: 7")
   end
+
+  it 'has a form that is already filled out for a holiday discount' do
+    visit "/merchant/#{@merchant.id}/bulk_discounts/new?holiday=0"
+
+    expect(page).to have_content("Discount name: #{@holiday_1.name}")
+    click_button("Submit")
+
+    expect(current_path).to eq("/merchant/#{@merchant.id}/bulk_discounts")
+    expect(page).to have_content("20.0%")
+    expect(page).to have_content("3")
+  end
 end


### PR DESCRIPTION
Create a Holiday Discount

As a merchant,
when I visit the discounts index page,
In the Holiday Discounts section, I see a `create discount` button next to each of the 3 upcoming holidays.
When I click on the button I am taken to a new discount form that has the form fields auto populated with the following:

Discount name: <name of holiday> discount
Percentage Discount: 30
Quantity Threshold: 2

I can leave the information as is, or modify it before saving.
I should be redirected to the discounts index page where I see the newly created discount added to the list of discounts.
